### PR TITLE
Fix build on Clang 18.x (and maybe earlier)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 CC =	cc
 CONFIG = llvm-config
-CFLAGS = $(shell ${CONFIG} --cflags) -std=c++14 -Wno-strict-aliasing -fPIC
+CFLAGS = $(shell ${CONFIG} --cflags) -std=c++17 -Wno-strict-aliasing -fPIC
 LINK = $(CC)
 LDFLAGS = -fPIC -fvisibility-inlines-hidden -fno-common -g -shared
 

--- a/ngx-ast.cc
+++ b/ngx-ast.cc
@@ -168,27 +168,27 @@ private:
 	{
 		const char type = flags.back();
 		if (flags == "FD") {
-			return llvm::make_unique<PrintfArgChecker>(
+			return std::make_unique<PrintfArgChecker>(
 				int_arg_handler,
 				this->Context, this->CI);
 		}
 		if (flags == "FN") {
-			return llvm::make_unique<PrintfArgChecker>(
+			return std::make_unique<PrintfArgChecker>(
 				nxt_file_name_arg_handler,
 				this->Context, this->CI);
 		}
 		if (flags == "PI" || flags == "PT") {
-			return llvm::make_unique<PrintfArgChecker>(
+			return std::make_unique<PrintfArgChecker>(
 				pid_arg_handler,
 				this->Context, this->CI);
 		}
 		if (flags == "PF") {
-			return llvm::make_unique<PrintfArgChecker>(
+			return std::make_unique<PrintfArgChecker>(
 				nxt_fid_arg_handler,
 				this->Context, this->CI);
 		}
 		if (flags == "PH") {
-			return llvm::make_unique<PrintfArgChecker>(
+			return std::make_unique<PrintfArgChecker>(
 				pthread_arg_handler,
 				this->Context, this->CI);
 		}


### PR DESCRIPTION
This is for the 'Unit' branch to allow the plugin to build on recent versions of Clang.